### PR TITLE
Ajout du fichier pour les default settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{"markdown.copyFiles.destination": {
+    "**/*": "assets/"
+  }
+}


### PR DESCRIPTION
Ajout des settings qui permettent à tous ceux qui récupèrent le projet de directement enregistrer par défaut les images dans le dossier 'assets' du dossier 'docs'